### PR TITLE
Tell bots how they'll be referred to on init

### DIFF
--- a/201808/index.js
+++ b/201808/index.js
@@ -56,7 +56,7 @@ class COUP {
 		try {
 			this.ALLPLAYER.forEach( player => {
 				const bot = require(`./${ player }/index.js`);
-				this.BOTS[ player ] = new bot(player);
+				this.BOTS[ player ] = new bot({ name: player });
 
 				if(
 					!this.BOTS[ player ].OnTurn ||

--- a/201808/index.js
+++ b/201808/index.js
@@ -56,7 +56,7 @@ class COUP {
 		try {
 			this.ALLPLAYER.forEach( player => {
 				const bot = require(`./${ player }/index.js`);
-				this.BOTS[ player ] = new bot();
+				this.BOTS[ player ] = new bot(player);
 
 				if(
 					!this.BOTS[ player ].OnTurn ||


### PR DESCRIPTION
Without this bots need to hard code their own names or inspect their file paths.