### PR TITLE
Add 'card' to 'unsuccessful-challenge' history items

### DIFF
--- a/201808/index.js
+++ b/201808/index.js
@@ -394,6 +394,7 @@ class COUP {
 					type: 'unsuccessful-challenge',
 					action: 'swap-1',
 					from: challengee,
+					card: card,
 				});
 				console.log(`↬  ${ this.GetAvatar( challengee ) } put the ${ Style.yellow( card ) } back in the deck and drew a new card`);
 


### PR DESCRIPTION
When a player has met a challenge against them (and is returning a card to the deck to be re-dealt) inform players what the cards is